### PR TITLE
Cage setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can build fat jar on RPi with:
 
 - [ ] Use [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
   to flash Raspberry Pi OS 64-bit to a microSD card
-  - [ ] Click the gear icon (:gear:) for Advanced Options
+  - [ ] Click the :gear: icon for Advanced Options
     - [ ] Check `Enable SSH`
       - [ ] Check `Set username and password`
       - [ ] Set `Username` to `cage` and enter a `Password`
@@ -72,7 +72,13 @@ ssh cage@raspberrypi
 
 Follow the steps below to install `cage` on Pi 5.
 
-1. Install dependencies for `cage`:
+1. Make sure our OS is up-to-date
+
+    ```sh
+    sudo apt-get update && sudo apt-get -y upgrade
+    ```
+
+2. Install dependencies for `cage`:
 
     ```sh
     sudo apt-get -y install cmake libvulkan-dev libwlroots-dev
@@ -93,7 +99,7 @@ Follow the steps below to install `cage` on Pi 5.
         Build-time dependency scdoc found: NO (tried pkgconfig and cmake)
     </details>
 
-2. Build and install `cage`
+3. Build and install `cage`
 
     ```sh
     # our workspace
@@ -113,15 +119,15 @@ Follow the steps below to install `cage` on Pi 5.
     sudo ninja -C build install
     ```
 
-3. Clone this repository
+4. Clone this repository
 
     ```sh
     cd ~/devel
-    git clone git@github.com:embdur/PiKiosk.git -b cage-setup
+    git clone https://github.com/SergeySn/PiKiosk.git
     cd PiKiosk
     ```
 
-4. Start `cage` on boot
+5. Start `cage` on boot
 
     Copy the systemd unit file for cage:
     ```sh
@@ -144,6 +150,11 @@ Follow the steps below to install `cage` on Pi 5.
     ```
     </details>
 
+    Disable the default display manager
+    ```sh
+    sudo systemctl disable display-manager
+    ```
+
     Enable an instantiated service of `cage`
     ```sh
     sudo ln -s /etc/systemd/system/cage@.service \
@@ -155,7 +166,7 @@ Follow the steps below to install `cage` on Pi 5.
     sudo systemctl set-default graphical.target
     ```
 
-5. PAM configuration
+6. PAM configuration
 
     Copy the PAM configuration file for `cage`
     ```sh
@@ -167,8 +178,10 @@ Follow the steps below to install `cage` on Pi 5.
     This is the same PAM config as in the<a href="https://github.com/cage-kiosk/cage/wiki/Starting-Cage-on-boot-with-systemd">cage wiki</a>
     </details>
 
-6. Reboot the Pi 5
+7. Reboot the Pi 5
 
     ```sh
     sudo reboot
     ```
+
+After reboot, `cage` will start the `galculator` app in kiosk mode.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,151 @@ Then run it with:
 You can build fat jar on RPi with:
 
 ./gradlew packageUberJarForCurrentOS
+
+## OS Installation
+
+- [ ] Use [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+  to flash Raspberry Pi OS 64-bit to a microSD card
+  - [ ] Click the gear icon (:gear:) for Advanced Options
+    - [ ] Check `Enable SSH`
+      - [ ] Check `Set username and password`
+      - [ ] Set `Username` to `cage` and enter a `Password`
+    - [ ] Check `Configure Wireless LAN`
+      - [ ] Enter `SSID` and `Password` for your Wi-Fi network
+      - [ ] Select `Wireless LAN Country`
+    - [ ] Check `Set locale settings`
+      - [ ] Select `Time zone` and `Keyboard layout`
+    - [ ] Click `Save`
+  - [ ] Select `RASPBERRY PI OS(64-BIT)` as `Operating System`
+  - [ ] Click `CHOOSE STORAGE` and select the microSD card
+  - [ ] Click `WRITE`
+
+If you need to change any of these settings later, run `sudo raspi-config` in a
+terminal on the Pi 5.
+
+The username `cage` is important here as it is used by the systemd service.
+If you use a different username, you will need to update the systemd service
+or add the `cage` user later(e.g. with `sudo useradd cage`)
+
+## Hardware Setup
+
+- [ ] Connect the following h/w with the Pi 5
+  - [ ] a monitor/screen
+  - [ ] a keyboard
+  - [ ] and a mouse
+- [ ] Insert the microSD card into the Pi 5
+- [ ] Connect Pi 5 to the power supply
+
+Pi 5 will boot up and show the desktop environment.
+
+
+## Setup Cage
+
+`ssh` into the Pi 5 with the username and password you set during the OS installation.
+
+```sh
+ssh cage@raspberrypi
+```
+
+Follow the steps below to install `cage` on Pi 5.
+
+1. Install dependencies for `cage`:
+
+    ```sh
+    sudo apt-get -y install cmake libvulkan-dev libwlroots-dev
+    ```
+
+    <details>
+    <summary>Optional: Building man pages</summary>
+        Append `scdoc` to above command if you need cage man pages.
+    </details>
+
+    <details>
+    <summary>Notes</summary>
+        Without the dependencies, `meson setup build` will fail with the
+    following error message(s)/warning(s):
+
+        Found CMake: NO
+        Run-time dependency wlroots found: NO (tried pkgconfig and cmake)
+        Build-time dependency scdoc found: NO (tried pkgconfig and cmake)
+    </details>
+
+2. Build and install `cage`
+
+    ```sh
+    # our workspace
+    mkdir ~/devel && cd ~/devel
+
+    # master branch requires a higher version of libwlroots-dev
+    git clone https://github.com/cage-kiosk/cage.git -b v0.1.5
+    cd cage
+
+    # Configure
+    meson setup build --buildtype=release -Dxwayland=true -Dprefix=/usr
+
+    # Build
+    ninja -C build
+
+    # Install
+    sudo ninja -C build install
+    ```
+
+3. Clone this repository
+
+    ```sh
+    cd ~/devel
+    git clone git@github.com:embdur/PiKiosk.git -b cage-setup
+    cd PiKiosk
+    ```
+
+4. Start `cage` on boot
+
+    Copy the systemd unit file for cage:
+    ```sh
+    sudo cp etc/systemd/system/cage@.service /etc/systemd/system/cage@.service
+    ```
+
+    <details>
+    <summary>Notes</summary>
+    This is the same template as in the <a href="https://github.com/cage-kiosk/cage/wiki/Starting-Cage-on-boot-with-systemd">cage wiki</a>
+
+    The only difference is that we replace the following line
+
+    ```sh
+    ExecStart=/usr/bin/cage /usr/bin/gtk3-widget-factory
+    ```
+    with
+
+    ```sh
+    ExecStart=/usr/bin/cage /usr/bin/galculator
+    ```
+    </details>
+
+    Enable an instantiated service of `cage`
+    ```sh
+    sudo ln -s /etc/systemd/system/cage@.service \
+        /etc/systemd/system/graphical.target.wants/cage@tty1.service
+    ```
+
+    Change systemd's default target to the graphical target
+    ```sh
+    sudo systemctl set-default graphical.target
+    ```
+
+5. PAM configuration
+
+    Copy the PAM configuration file for `cage`
+    ```sh
+    sudo cp etc/pam.d/cage /etc/pam.d/cage
+    ```
+
+    <details>
+    <summary>Notes</summary>
+    This is the same PAM config as in the<a href="https://github.com/cage-kiosk/cage/wiki/Starting-Cage-on-boot-with-systemd">cage wiki</a>
+    </details>
+
+6. Reboot the Pi 5
+
+    ```sh
+    sudo reboot
+    ```

--- a/etc/pam.d/cage
+++ b/etc/pam.d/cage
@@ -1,0 +1,4 @@
+auth           required        pam_unix.so nullok
+account        required        pam_unix.so
+session        required        pam_unix.so
+session        required        pam_systemd.so

--- a/etc/systemd/system/cage@.service
+++ b/etc/systemd/system/cage@.service
@@ -1,0 +1,46 @@
+# This is a system unit for launching Cage with auto-login as the
+# user configured here. For this to work, wlroots must be built
+# with systemd logind support.
+
+[Unit]
+Description=Cage Wayland compositor on %I
+# Make sure we are started after logins are permitted. If Plymouth is
+# used, we want to start when it is on its way out.
+After=systemd-user-sessions.service plymouth-quit-wait.service
+# Since we are part of the graphical session, make sure we are started
+# before it is complete.
+Before=graphical.target
+# On systems without virtual consoles, do not start.
+ConditionPathExists=/dev/tty0
+# D-Bus is necessary for contacting logind, which is required.
+Wants=dbus.socket systemd-logind.service
+After=dbus.socket systemd-logind.service
+# Replace any (a)getty that may have spawned, since we log in
+# automatically.
+Conflicts=getty@%i.service
+After=getty@%i.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/cage /usr/bin/gtk3-widget-factory
+Restart=always
+User=cage
+# Log this user with utmp, letting it show up with commands 'w' and
+# 'who'. This is needed since we replace (a)getty.
+UtmpIdentifier=%I
+UtmpMode=user
+# A virtual terminal is needed.
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+# Fail to start if not controlling the virtual terminal.
+StandardInput=tty-fail
+
+# Set up a full (custom) user session for the user, required by Cage.
+PAMName=cage
+
+[Install]
+WantedBy=graphical.target
+Alias=display-manager.service
+DefaultInstance=tty7

--- a/etc/systemd/system/cage@.service
+++ b/etc/systemd/system/cage@.service
@@ -22,7 +22,7 @@ After=getty@%i.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/cage /usr/bin/gtk3-widget-factory
+ExecStart=/usr/bin/cage /usr/bin/galculator
 Restart=always
 User=cage
 # Log this user with utmp, letting it show up with commands 'w' and


### PR DESCRIPTION
Instructions for setting up cage on Pi 5.
For now, we run `galculator` in kiosk mode with cage.
The README.md will be updated later to include instructions for Kotlin Desktop Compose app.

Signed-off-by: Abdur Rehman <abdur.rehman@linux.com>